### PR TITLE
fix: 로그인 확인 API 응답으로 해당 유저의 로그인아이디를 반환하도록 수정

### DIFF
--- a/src/main/java/com/codingchosun/backend/controller/user/LoginCheckController.java
+++ b/src/main/java/com/codingchosun/backend/controller/user/LoginCheckController.java
@@ -1,6 +1,7 @@
 package com.codingchosun.backend.controller.user;
 
 import com.codingchosun.backend.dto.response.ApiResponse;
+import com.codingchosun.backend.dto.response.LoginCheckResponse;
 import com.codingchosun.backend.service.user.LoginService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +17,9 @@ public class LoginCheckController {
     private final LoginService loginService;
 
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<String>> getLoggedInUser(@AuthenticationPrincipal UserDetails userDetails) {
-        loginService.loggedInCheck(userDetails);
+    public ResponseEntity<ApiResponse<LoginCheckResponse>> getLoggedInUser(@AuthenticationPrincipal UserDetails userDetails) {
+        LoginCheckResponse loginCheckResponse = loginService.loggedInCheck(userDetails);
 
-        return ApiResponse.ok("로그인 확인에 성공히였습니다.");
+        return ApiResponse.ok(loginCheckResponse);
     }
 }

--- a/src/main/java/com/codingchosun/backend/dto/response/LoginCheckResponse.java
+++ b/src/main/java/com/codingchosun/backend/dto/response/LoginCheckResponse.java
@@ -1,0 +1,12 @@
+package com.codingchosun.backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginCheckResponse {
+
+    private Long userId;
+
+}

--- a/src/main/java/com/codingchosun/backend/service/user/LoginService.java
+++ b/src/main/java/com/codingchosun/backend/service/user/LoginService.java
@@ -1,6 +1,8 @@
 package com.codingchosun.backend.service.user;
 
+import com.codingchosun.backend.domain.User;
 import com.codingchosun.backend.dto.request.LoginRequest;
+import com.codingchosun.backend.dto.response.LoginCheckResponse;
 import com.codingchosun.backend.exception.common.ErrorCode;
 import com.codingchosun.backend.exception.login.LoginProcessFailedException;
 import com.codingchosun.backend.exception.login.NotAuthenticatedException;
@@ -53,13 +55,15 @@ public class LoginService {
     }
 
     @Transactional(readOnly = true)
-    public void loggedInCheck(UserDetails userDetails) {
+    public LoginCheckResponse loggedInCheck(UserDetails userDetails) {
         if (userDetails == null) {
             throw new NotAuthenticatedException(ErrorCode.AUTHENTICATION_REQUIRED);
         }
 
-        dataJpaUserRepository.findByLoginId(userDetails.getUsername()).orElseThrow(
+        User user = dataJpaUserRepository.findByLoginId(userDetails.getUsername()).orElseThrow(
                 () -> new UserNotFoundFromDB(ErrorCode.USER_NOT_FOUND)
         );
+
+        return new LoginCheckResponse(user.getUserId());
     }
 }


### PR DESCRIPTION
프론트에서 어떤 유저인지 확인하고 관련 API 를 호출하기 위해서 로그인 아이디를 반환하도록 API 를 수정함